### PR TITLE
Add stub kubeconfig step for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!--------------------- Don't add new entries after this line --------------------->
 
+## 0.1.7 - 2024-09-12
+
+### Added
+
+- `Kubereq.Kubeconfig.Stub`: A Kubeconfig step used for testing
+
 ## 0.1.6 - 2024-08-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -120,3 +120,11 @@ req = Kubereq.new(kubeconfig, "api/v1/namespaces/:namespace/configmaps/:name")
 
 `resp` is a `Req.Response.t()` and you can check for `req.status` and get
 `req.body` etc.
+
+## Testing / Stubbing
+
+Since `kubereq` is using `Req` under the hood, we can use
+[`Req.Test`](https://hexdocs.pm/req/Req.Test.html) to run requests through
+mocks/stubs. Use the special `Kubereq.Kubeconfig.Stub` to set stubs on the
+resulting `Req.Request` structs. See `Kubereq.Kubeconfig.Stub` for further
+documentation

--- a/lib/kubereq.ex
+++ b/lib/kubereq.ex
@@ -69,6 +69,7 @@ defmodule Kubereq do
     |> Step.Auth.attach()
     |> Step.Impersonate.attach()
     |> Step.BaseUrl.attach()
+    |> Step.Plug.attach()
     |> Req.merge(kubeconfig: kubeconfig)
   end
 
@@ -109,7 +110,7 @@ defmodule Kubereq do
 
   ### Example
 
-      iex> Kubereq.Client.create(req, resource)
+      iex> Kubereq.create(req, resource)
       {:ok, %Req.Response{status: 201, body: %{...}}}
   """
   @spec create(Req.Request.t(), resource :: map()) :: response()
@@ -127,7 +128,7 @@ defmodule Kubereq do
 
   ### Example
 
-      iex> Kubereq.Client.get(req, "default", "foo")
+      iex> Kubereq.get(req, "default", "foo")
       {:ok, %Req.Response{status: 200, body: %{...}}}
   """
   @spec get(Req.Request.t(), namespace :: namespace(), name :: String.t()) ::
@@ -142,7 +143,7 @@ defmodule Kubereq do
 
   ### Examples
 
-      iex> Kubereq.Client.list(req, "api/v1/namespaces/:namespace/configmaps", "default", [])
+      iex> Kubereq.list(req, "api/v1/namespaces/:namespace/configmaps", "default", [])
       {:ok, %Req.Response{status: 200, body: %{...}}}
 
   ### Options
@@ -167,7 +168,7 @@ defmodule Kubereq do
 
   ### Examples
 
-      iex> Kubereq.Client.delete(req, "default", "foo")
+      iex> Kubereq.delete(req, "default", "foo")
       {:ok, %Req.Response{status: 200, body: %{...}}}
   """
   @spec delete(Req.Request.t(), namespace :: namespace(), name :: String.t()) ::
@@ -185,7 +186,7 @@ defmodule Kubereq do
 
   ### Examples
 
-      iex> Kubereq.Client.delete_all(req, "default", "foo")
+      iex> Kubereq.delete_all(req, "default", "foo")
       {:ok, %Req.Response{...}
 
   ### Options
@@ -209,7 +210,7 @@ defmodule Kubereq do
 
   ### Examples
 
-      iex> Kubereq.Client.update(req, %{...})
+      iex> Kubereq.update(req, %{...})
       {:ok, %Req.Response{...}
   """
   @spec update(Req.Request.t(), resource :: map()) :: response()
@@ -233,7 +234,7 @@ defmodule Kubereq do
 
   ### Examples
 
-      iex> Kubereq.Client.apply(req, %{...})
+      iex> Kubereq.apply(req, %{...})
       {:ok, %Req.Response{...}
   """
   @spec apply(Req.Request.t(), resource :: map(), field_manager :: binary(), force :: boolean()) ::
@@ -257,7 +258,7 @@ defmodule Kubereq do
 
   ### Examples
 
-      iex> Kubereq.Client.json_patch(req, %{...}, "default", "foo")
+      iex> Kubereq.json_patch(req, %{...}, "default", "foo")
       {:ok, %Req.Response{...}
   """
   @spec json_patch(
@@ -281,7 +282,7 @@ defmodule Kubereq do
 
   ### Examples
 
-      iex> Kubereq.Client.merge_patch(req, %{...}, "default", "foo")
+      iex> Kubereq.merge_patch(req, %{...}, "default", "foo")
       {:ok, %Req.Response{...}
   """
   @spec merge_patch(
@@ -364,12 +365,12 @@ defmodule Kubereq do
 
   ### Examples
 
-      iex> Kubereq.Client.watch(req, "default", [])
+      iex> Kubereq.watch(req, "default", [])
       {:ok, #Function<60.48886818/2 in Stream.transform/3>}
 
   In order to watch events in all namespaces, pass `nil` as namespace:
 
-      iex> Kubereq.Client.watch(req, nil, [])
+      iex> Kubereq.watch(req, nil, [])
       {:ok, #Function<60.48886818/2 in Stream.transform/3>}
 
   ### Options
@@ -409,12 +410,12 @@ defmodule Kubereq do
 
   ### Examples
 
-      iex> Kubereq.Client.watch_single(req, "default", [])
+      iex> Kubereq.watch_single(req, "default", [])
       {:ok, #Function<60.48886818/2 in Stream.transform/3>}
 
   In order to watch events in all namespaces, pass `nil` as namespace:
 
-      iex> Kubereq.Client.watch_single(req, nil, [])
+      iex> Kubereq.watch_single(req, nil, [])
       {:ok, #Function<60.48886818/2 in Stream.transform/3>}
 
   ### Options

--- a/lib/kubereq/kubeconfig/stub.ex
+++ b/lib/kubereq/kubeconfig/stub.ex
@@ -1,0 +1,141 @@
+defmodule Kubereq.Kubeconfig.Stub do
+  @moduledoc """
+  Req testing conveniences for `kubereq` requests.
+
+  Since `kubereq` is using `Req` under the hood, we can use
+  [`Req.Test`](https://hexdocs.pm/req/Req.Test.html) to run requests through
+  mocks/stubs. Using this step as your Kubeconfig pipeline, you can set a stub
+  on the `Req.Request` configured by this step.
+
+  In your tests, you can then use `Req.Test` according to its documentation.
+
+  ## Example
+
+  Imagine we're building an app with a pod client that lists pods on the
+  cluster.
+
+  We start off by defining a module for loading the Kubernetes config:
+
+      defmodule MyApp.Kubeconfig do
+        @kubeconfig_pipeline Application.compile_env(:myapp, :kubeconfig_pipeline)
+
+        def load(), do: Kubereq.Kubeconfig.load(@kubeconfig_pipeline)
+      end
+
+  We then implement the pod client using the Kubeconfig loader to create a
+  `Req.Request`:
+
+      defmodule MyApp.PodClient do
+        @resource_path "api/v1/namespaces/:namespace/pods/:name"
+
+        def list(namespace) do
+          req = Kubereq.new(MyApp.Kubeconfig.load(), @resource_path)
+
+          {:ok, resp} = Kubereq.list(req, namespace)
+          resp.body["items"]
+        end
+      end
+
+  We configure the kubeconfig pipeline for production using
+  `Kubereq.Kubeconfig.Default` as our pipeline to load the Kubeconfig:
+
+      # config/prod.exs
+      config :myapp, kubeconfig_pipeline: Kubereq.Kubeconfig.Default
+
+  In tests, instead of sending requests to the cluster, we make the request
+  against a plug stub named `MyApp.Cluster`:
+
+      # config/test.exs
+      config :myapp, kubeconfig_pipeline: {Kubereq.Kubeconfig.Stub, plugs: {Req.Test, MyApp.Cluster}}
+
+  Now we can control our stubs in concurrent tests:
+
+      use ExUnit.Case, async: true
+
+      test "many pods" do
+        Req.Test.stub(MyApp.Cluster, fn conn ->
+          Req.Test.json(conn, %{
+            "apiVersion" => "v1",
+            "kind" => "List",
+            "items" => [
+              %{
+                "apiVersion" => "v1",
+                "kind" => "Pod"
+                # ...
+              }
+            ]
+          })
+        end)
+
+        assert [_] = MyApp.PodClient.list("default")
+      end
+
+  ## Stubs per Context
+
+  If you want to simulate multiple different clusters or different responses for
+  the same calls, you can pass a `%{context :: String.t() => plug :: tuple}` map
+  to as `plugs` option.
+
+      # config/test.exs
+      config :myapp, kubeconfig_pipeline: {Kubereq.Kubeconfig.Stub, plugs: %{
+        "happy-path" => {Req.Test, MyApp.HappyPathCluster}
+        "missing-permissions" => {Req.Test, MyApp.MissingPermissionsCluster}
+      }}
+
+  ## Options
+
+  * `plugs` - The plug or `%{context => plug}` map to be configured on the
+    `Req.Request` configured by this step.
+  """
+
+  @behaviour Pluggable
+
+  @impl true
+  @spec init(keyword()) :: keyword()
+  def init(opts \\ []) do
+    if !opts[:plugs] do
+      raise ArgumentError, "You have to pass the :plugs option to use this step."
+    end
+
+    Keyword.validate!(opts, [:plugs])
+  end
+
+  @impl true
+  @spec call(Kubereq.Kubeconfig.t(), keyword()) :: Kubereq.Kubeconfig.t()
+  def call(_kubeconf, opts) do
+    user = %{
+      "name" => "dummy",
+      "user" => %{}
+    }
+
+    plugs =
+      if is_tuple(opts[:plugs]) do
+        %{"default" => opts[:plugs]}
+      else
+        opts[:plugs]
+      end
+
+    {clusters, contexts} =
+      for {context_name, plug} <- plugs, reduce: {[], []} do
+        {clusters, contexts} ->
+          cluster = %{
+            "name" => context_name,
+            "cluster" => %{"plug" => plug, "server" => "http://stub.local"}
+          }
+
+          context = %{
+            "name" => context_name,
+            "context" => %{
+              "cluster" => context_name,
+              "user" => "dummy",
+              "namespace" => "default"
+            }
+          }
+
+          {[cluster | clusters], [context | contexts]}
+      end
+
+    Kubereq.Kubeconfig.new!(clusters: clusters, users: [user], contexts: contexts)
+    |> Kubereq.Kubeconfig.set_current_context(get_in(contexts, [Access.at(0), "name"]))
+  end
+end

--- a/lib/kubereq/step/plug.ex
+++ b/lib/kubereq/step/plug.ex
@@ -1,0 +1,24 @@
+defmodule Kubereq.Step.Plug do
+  @moduledoc """
+  Req step to derive the base URL to the cluster.
+  """
+
+  alias Kubereq.Error.StepError
+
+  @spec attach(Req.Request.t()) :: Req.Request.t()
+  def attach(req) do
+    Req.Request.prepend_request_steps(req, kubereq_plug: &call/1)
+  end
+
+  @spec call(req :: Req.Request.t()) :: Req.Request.t()
+  def call(req) when not is_map_key(req.options, :kubeconfig) do
+    raise StepError.new(:kubeconfig_not_loaded)
+  end
+
+  def call(req) do
+    case req.options.kubeconfig.current_cluster["plug"] do
+      nil -> req
+      plug -> Req.merge(req, plug: plug)
+    end
+  end
+end

--- a/test/kubereq/step/plug_test.exs
+++ b/test/kubereq/step/plug_test.exs
@@ -1,0 +1,66 @@
+defmodule Kubereq.Step.PlugTest do
+  use ExUnit.Case, async: true
+
+  alias Kubereq.Step.Plug, as: MUT
+
+  alias Kubereq.Kubeconfig
+
+  test "raises if no kubeconfig" do
+    assert_raise Kubereq.Error.StepError, fn -> MUT.call(Req.new()) end
+  end
+
+  test "sets a single plug on the req" do
+    Req.Test.stub(Kubereq.Step.PlugTest, fn conn ->
+      assert conn.host == "stub.local"
+      Plug.Conn.send_resp(conn, 200, "Plug called")
+    end)
+
+    kubeconfig =
+      Kubeconfig.Stub.call(
+        %Kubeconfig{},
+        Kubeconfig.Stub.init(plugs: {Req.Test, Kubereq.Step.PlugTest})
+      )
+
+    {:ok, resp} =
+      kubeconfig
+      |> Kubereq.new("unused")
+      |> MUT.call()
+      |> Req.request()
+
+    assert resp.body == "Plug called"
+  end
+
+  test "sets multiple plugs on the req" do
+    Req.Test.stub(Kubereq.Step.Foo, &Plug.Conn.send_resp(&1, 200, "Foo called"))
+    Req.Test.stub(Kubereq.Step.Bar, &Plug.Conn.send_resp(&1, 200, "Bar called"))
+
+    plugs = %{
+      "foo" => {Req.Test, Kubereq.Step.Foo},
+      "bar" => {Req.Test, Kubereq.Step.Bar}
+    }
+
+    kubeconfig =
+      Kubeconfig.Stub.call(
+        %Kubeconfig{},
+        Kubeconfig.Stub.init(plugs: plugs)
+      )
+
+    {:ok, resp} =
+      kubeconfig
+      |> Kubeconfig.set_current_context("foo")
+      |> Kubereq.new("unused")
+      |> MUT.call()
+      |> Req.request()
+
+    assert resp.body == "Foo called"
+
+    {:ok, resp} =
+      kubeconfig
+      |> Kubeconfig.set_current_context("bar")
+      |> Kubereq.new("unused")
+      |> MUT.call()
+      |> Req.request()
+
+    assert resp.body == "Bar called"
+  end
+end


### PR DESCRIPTION
## Kubereq.Kubeconfig.Stub

Req testing conveniences for `kubereq` requests.

Since `kubereq` is using `Req` under the hood, we can use
[`Req.Test`](https://hexdocs.pm/req/Req.Test.html) to run requests through
mocks/stubs. Using this step as your Kubeconfig pipeline, you can set a stub
on the `Req.Request` configured by this step.

In your tests, you can then use `Req.Test` according to its documentation.

## Example

Imagine we're building an app with a pod client that lists pods on the
cluster.

We start off by defining a module for loading the Kubernetes config:

```ex
defmodule MyApp.Kubeconfig do
  @kubeconfig_pipeline Application.compile_env(:myapp, :kubeconfig_pipeline)

  def load(), do: Kubereq.Kubeconfig.load(@kubeconfig_pipeline)
end
```

We then implement the pod client using the Kubeconfig loader to create a
`Req.Request`:

```ex
defmodule MyApp.PodClient do
  @resource_path "api/v1/namespaces/:namespace/pods/:name"

  def list(namespace) do
    req = Kubereq.new(MyApp.Kubeconfig.load(), @resource_path)

    {:ok, resp} = Kubereq.list(req, namespace)
    resp.body["items"]
  end
end
```

We configure the kubeconfig pipeline for production using
`Kubereq.Kubeconfig.Default` as our pipeline to load the Kubeconfig:

```ex
# config/prod.exs
config :myapp, kubeconfig_pipeline: Kubereq.Kubeconfig.Default
```

In tests, instead of sending requests to the cluster, we make the request
against a plug stub named `MyApp.Cluster`:

```ex
# config/test.exs
config :myapp, kubeconfig_pipeline: {Kubereq.Kubeconfig.Stub, plugs: {Req.Test, MyApp.Cluster}}
```

Now we can control our stubs in concurrent tests:

```ex
use ExUnit.Case, async: true

test "many pods" do
  Req.Test.stub(MyApp.Cluster, fn conn ->
    Req.Test.json(conn, %{
      "apiVersion" => "v1",
      "kind" => "List",
      "items" => [
        %{
          "apiVersion" => "v1",
          "kind" => "Pod"
          # ...
        }
      ]
    })
  end)

  assert [_] = MyApp.PodClient.list("default")
end
```

## Stubs per Context

If you want to simulate multiple different clusters or different responses for
the same calls, you can pass a `%{context :: String.t() => plug :: tuple}` map
to as `plugs` option.

```ex
# config/test.exs
config :myapp, kubeconfig_pipeline: {Kubereq.Kubeconfig.Stub, plugs: %{
  "happy-path" => {Req.Test, MyApp.HappyPathCluster}
  "missing-permissions" => {Req.Test, MyApp.MissingPermissionsCluster}
}}
```

## Options

* `plugs` - The plug or `%{context => plug}` map to be configured on the
  `Req.Request` configured by this step.
