### PR TITLE
Set server URL to context name in stub kubeconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!--------------------- Don't add new entries after this line --------------------->
 
+## 0.1.8 - 2024-09-14
+
+### Changed
+
+- `Kubereq.Kubeconfig.Stub`: Set server url to context name
+
 ## 0.1.7 - 2024-09-12
 
 ### Added

--- a/lib/kubereq/kubeconfig/stub.ex
+++ b/lib/kubereq/kubeconfig/stub.ex
@@ -120,7 +120,7 @@ defmodule Kubereq.Kubeconfig.Stub do
         {clusters, contexts} ->
           cluster = %{
             "name" => context_name,
-            "cluster" => %{"plug" => plug, "server" => "http://stub.local"}
+            "cluster" => %{"plug" => plug, "server" => "https://#{context_name}"}
           }
 
           context = %{

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Kubereq.MixProject do
 
   @app :kubereq
   @source_url "https://github.com/mruoss/#{@app}"
-  @version "0.1.7"
+  @version "0.1.8"
 
   def project do
     [

--- a/test/kubereq/step/plug_test.exs
+++ b/test/kubereq/step/plug_test.exs
@@ -11,7 +11,7 @@ defmodule Kubereq.Step.PlugTest do
 
   test "sets a single plug on the req" do
     Req.Test.stub(Kubereq.Step.PlugTest, fn conn ->
-      assert conn.host == "stub.local"
+      assert conn.host == "default"
       Plug.Conn.send_resp(conn, 200, "Plug called")
     end)
 
@@ -31,8 +31,15 @@ defmodule Kubereq.Step.PlugTest do
   end
 
   test "sets multiple plugs on the req" do
-    Req.Test.stub(Kubereq.Step.Foo, &Plug.Conn.send_resp(&1, 200, "Foo called"))
-    Req.Test.stub(Kubereq.Step.Bar, &Plug.Conn.send_resp(&1, 200, "Bar called"))
+    Req.Test.stub(Kubereq.Step.Foo, fn conn ->
+      assert conn.host == "foo"
+      Plug.Conn.send_resp(conn, 200, "Foo called")
+    end)
+
+    Req.Test.stub(Kubereq.Step.Bar, fn conn ->
+      assert conn.host == "bar"
+      Plug.Conn.send_resp(conn, 200, "Bar called")
+    end)
 
     plugs = %{
       "foo" => {Req.Test, Kubereq.Step.Foo},


### PR DESCRIPTION
This way the stub gets information about the context in via `conn.host`.