### PR TITLE
Use correct Req error handling instead of raising exceptions

### DIFF
--- a/lib/kubereq/error/kubeconf_error.ex
+++ b/lib/kubereq/error/kubeconf_error.ex
@@ -16,16 +16,19 @@ defmodule Kubereq.Error.KubeconfError do
   @errors %{
     config_already_set: "The Kubernetes configuration is already set.",
     cert_prep_failed: "Failed to prepare the certificate data.",
-    exec_conf_decode_failed: "Failed to decode the exec configuration",
-    env_var_empty: "The given ENV variable is empty"
+    exec_conf_decode_failed: "Failed to decode the exec configuration.",
+    exec_cmd_failed: "Execution of command defined in your exec condfiguration failed.",
+    env_var_empty: "The given ENV variable is empty."
   }
 
-  @spec new(atom(), Exception.t() | nil) :: t()
-  def new(code, upstream \\ nil)
+  @spec new(atom(), Keyword.t() | nil) :: t()
+  def new(code, fields \\ [])
 
   for {code, message} <- @errors do
-    def new(unquote(code), upstream) do
-      struct!(__MODULE__, code: unquote(code), message: unquote(message), upstream: upstream)
+    def new(unquote(code), fields) do
+      fields = Keyword.merge([code: unquote(code), message: unquote(message)], fields)
+
+      struct!(__MODULE__, fields)
     end
   end
 end

--- a/lib/kubereq/exec.ex
+++ b/lib/kubereq/exec.ex
@@ -22,8 +22,11 @@ defmodule Kubereq.Exec do
       case Registry.lookup(__MODULE__, config_hash) do
         [] ->
           name = {:via, Registry, {__MODULE__, config_hash}}
-          {:ok, pid} = start_link(config, name: name)
-          pid
+
+          case start_link(config, name: name) do
+            {:ok, pid} -> pid
+            {:error, {:already_started, pid}} -> pid
+          end
 
         [{pid, _}] ->
           pid
@@ -89,7 +92,7 @@ defmodule Kubereq.Exec do
               :exec_cmd_failed,
               message:
                 config["installHint"] ||
-                  ~s'Exec command "#{config["command"]}" defined in your Kubeconfig was not found.',
+                  ~s|Could not find exec command "#{config["command"]}" (defined in your Kubeconfig) in PATH.|,
               upstream: error
             )
 

--- a/lib/kubereq/step/base_url.ex
+++ b/lib/kubereq/step/base_url.ex
@@ -12,7 +12,7 @@ defmodule Kubereq.Step.BaseUrl do
 
   @spec call(req :: Req.Request.t()) :: Req.Request.t()
   def call(req) when not is_map_key(req.options, :kubeconfig) do
-    raise StepError.new(:kubeconfig_not_loaded)
+    {req, StepError.new(:kubeconfig_not_loaded)}
   end
 
   def call(req) do

--- a/lib/kubereq/step/compression.ex
+++ b/lib/kubereq/step/compression.ex
@@ -12,7 +12,7 @@ defmodule Kubereq.Step.Compression do
 
   @spec call(req :: Req.Request.t()) :: Req.Request.t()
   def call(req) when not is_map_key(req.options, :kubeconfig) do
-    raise StepError.new(:kubeconfig_not_loaded)
+    {req, StepError.new(:kubeconfig_not_loaded)}
   end
 
   def call(req) do

--- a/lib/kubereq/step/impersonate.ex
+++ b/lib/kubereq/step/impersonate.ex
@@ -12,7 +12,7 @@ defmodule Kubereq.Step.Impersonate do
 
   @spec call(req :: Req.Request.t()) :: Req.Request.t()
   def call(req) when not is_map_key(req.options, :kubeconfig) do
-    raise StepError.new(:kubeconfig_not_loaded)
+    {req, StepError.new(:kubeconfig_not_loaded)}
   end
 
   def call(req) do

--- a/lib/kubereq/step/plug.ex
+++ b/lib/kubereq/step/plug.ex
@@ -12,7 +12,7 @@ defmodule Kubereq.Step.Plug do
 
   @spec call(req :: Req.Request.t()) :: Req.Request.t()
   def call(req) when not is_map_key(req.options, :kubeconfig) do
-    raise StepError.new(:kubeconfig_not_loaded)
+    {req, StepError.new(:kubeconfig_not_loaded)}
   end
 
   def call(req) do

--- a/lib/kubereq/step/tls.ex
+++ b/lib/kubereq/step/tls.ex
@@ -13,7 +13,7 @@ defmodule Kubereq.Step.TLS do
 
   @spec call(req :: Req.Request.t()) :: Req.Request.t()
   def call(req) when not is_map_key(req.options, :kubeconfig) do
-    raise StepError.new(:kubeconfig_not_loaded)
+    {req, StepError.new(:kubeconfig_not_loaded)}
   end
 
   def call(req) do
@@ -45,7 +45,7 @@ defmodule Kubereq.Step.TLS do
 
     {:cacerts, [cacert_data]}
   rescue
-    _ -> reraise KubeconfError.new(:cert_prep_failed), __STACKTRACE__
+    error -> reraise KubeconfError.new(:cert_prep_failed, upstream: error), __STACKTRACE__
   end
 
   defp ca_cert!(_), do: nil

--- a/test/kubereq/step/auth_test.exs
+++ b/test/kubereq/step/auth_test.exs
@@ -4,7 +4,9 @@ defmodule Kubereq.Step.AuthTest do
   alias Kubereq.Step.Auth, as: MUT
 
   test "raises if no kubeconfig" do
-    assert_raise Kubereq.Error.StepError, fn -> MUT.call(Req.new()) end
+    {_req, error} = MUT.call(Req.new())
+    assert is_struct(error, Kubereq.Error.StepError)
+    assert error.code == :kubeconfig_not_loaded
   end
 
   test "Sets certfile and keyfile transport options" do

--- a/test/kubereq/step/base_url_test.exs
+++ b/test/kubereq/step/base_url_test.exs
@@ -4,7 +4,9 @@ defmodule Kubereq.Step.BaseUrlTest do
   alias Kubereq.Step.BaseUrl, as: MUT
 
   test "raises if no kubeconfig" do
-    assert_raise Kubereq.Error.StepError, fn -> MUT.call(Req.new()) end
+    {_req, error} = MUT.call(Req.new())
+    assert is_struct(error, Kubereq.Error.StepError)
+    assert error.code == :kubeconfig_not_loaded
   end
 
   test "sets the base url" do

--- a/test/kubereq/step/compression_test.exs
+++ b/test/kubereq/step/compression_test.exs
@@ -4,7 +4,9 @@ defmodule Kubereq.Step.CompressionTest do
   alias Kubereq.Step.Compression, as: MUT
 
   test "raises if no kubeconfig" do
-    assert_raise Kubereq.Error.StepError, fn -> MUT.call(Req.new()) end
+    {_req, error} = MUT.call(Req.new())
+    assert is_struct(error, Kubereq.Error.StepError)
+    assert error.code == :kubeconfig_not_loaded
   end
 
   test "enables compression by default" do

--- a/test/kubereq/step/impersonate_test.exs
+++ b/test/kubereq/step/impersonate_test.exs
@@ -4,7 +4,9 @@ defmodule Kubereq.Step.ImpersonateTest do
   alias Kubereq.Step.Impersonate, as: MUT
 
   test "raises if no kubeconfig" do
-    assert_raise Kubereq.Error.StepError, fn -> MUT.call(Req.new()) end
+    {_req, error} = MUT.call(Req.new())
+    assert is_struct(error, Kubereq.Error.StepError)
+    assert error.code == :kubeconfig_not_loaded
   end
 
   @tag :wip

--- a/test/kubereq/step/plug_test.exs
+++ b/test/kubereq/step/plug_test.exs
@@ -6,7 +6,9 @@ defmodule Kubereq.Step.PlugTest do
   alias Kubereq.Kubeconfig
 
   test "raises if no kubeconfig" do
-    assert_raise Kubereq.Error.StepError, fn -> MUT.call(Req.new()) end
+    {_req, error} = MUT.call(Req.new())
+    assert is_struct(error, Kubereq.Error.StepError)
+    assert error.code == :kubeconfig_not_loaded
   end
 
   test "sets a single plug on the req" do

--- a/test/kubereq/step/tls_test.exs
+++ b/test/kubereq/step/tls_test.exs
@@ -4,7 +4,9 @@ defmodule Kubereq.Step.TLSTest do
   alias Kubereq.Step.TLS, as: MUT
 
   test "raises if no kubeconfig" do
-    assert_raise Kubereq.Error.StepError, fn -> MUT.call(Req.new()) end
+    {_req, error} = MUT.call(Req.new())
+    assert is_struct(error, Kubereq.Error.StepError)
+    assert error.code == :kubeconfig_not_loaded
   end
 
   test "sets the verify option" do


### PR DESCRIPTION
Before, when the exec command defined in the Kubeconf wasn't found, an exception was raised. This is now rescued into an error:

<img width="907" alt="Screenshot 2024-09-20 at 20 28 22" src="https://github.com/user-attachments/assets/79058d1d-57d5-4b68-b8f4-909c4be8d534">

