### PR TITLE
fix: remove temporary workaround which broke wildcard TLS matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!--------------------- Don't add new entries after this line --------------------->
 
+## 0.4.3 - 2026-07-20
+
+### Fixed
+
+- Remove temporary workaround which broke wildcard TLS certificate matching [#175](https://github.com/mruoss/kubereq/pull/175)
+
 ## 0.4.2 - 2025-04-06
 
 ### Added

--- a/lib/kubereq/step/tls.ex
+++ b/lib/kubereq/step/tls.ex
@@ -16,8 +16,7 @@ defmodule Kubereq.Step.TLS do
     [
       (cluster["insecure-skip-tls-verify"] && {:verify, :verify_none}) || {:verify, :verify_peer},
       ca_cert!(cluster),
-      sni(cluster),
-      {:customize_hostname_check, [match_fun: &check_ips_as_dns_id/2]}
+      sni(cluster)
     ]
     |> List.flatten()
     |> Enum.filter(& &1)
@@ -44,18 +43,4 @@ defmodule Kubereq.Step.TLS do
   end
 
   defp sni(_), do: nil
-
-  # Temporary workaround until this is fixed in some lower layer
-  # https://github.com/erlang/otp/issues/7968
-  @spec check_ips_as_dns_id({:dns_id}, charlist()) :: true | :default
-  defp check_ips_as_dns_id({:dns_id, hostname}, {:iPAddress, ip}) do
-    with {:ok, ip_tuple} <- :inet.parse_address(hostname),
-         ^ip <- Tuple.to_list(ip_tuple) do
-      true
-    else
-      _ -> :default
-    end
-  end
-
-  defp check_ips_as_dns_id(_, _), do: :default
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Kubereq.MixProject do
 
   @app :kubereq
   @source_url "https://github.com/mruoss/#{@app}"
-  @version "0.4.2"
+  @version "0.4.3"
 
   def project do
     [


### PR DESCRIPTION
This was fixed [upstream](https://github.com/elixir-mint/mint/pull/418) in Mint by now. Also, without other `match_fun` declared there, this code breaks wildcard TLS certificate matching and should be removed. 

```
** (Finch.TransportError) TLS client: In state wait_cert at ssl_handshake.erl:2178 generated CLIENT ALERT: Fatal - Handshake Failure
 {bad_cert,
     {hostname_check_failed,
         {requested,
             "gke-****.europe-west4-a.gke.goog"},
         {received,
             [{dNSName,"*.europe-west4.gke.goog"},
              {dNSName,"*.europe-west4-a.gke.goog"},
              {dNSName,"*.europe-west4-b.gke.goog"},
              {dNSName,"*.europe-west4-c.gke.goog"}]}}}
    (req 0.5.17) lib/req.ex:1125: Req.request!/2
    #cell:rrwb5h5pi7m6vpj3:1: (file)
```
